### PR TITLE
データベースの作り直し #35

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ ruby '2.5.1'
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.3'
 # Use sqlite3 as the database for Active Record
-gem 'sqlite3'
+#gem 'sqlite3'
 # Use Puma as the app server
 gem 'puma', '~> 3.11'
 # Use SCSS for stylesheets

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -204,7 +204,6 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    sqlite3 (1.4.2)
     thor (1.0.1)
     thread_safe (0.3.6)
     tilt (2.0.10)
@@ -253,7 +252,6 @@ DEPENDENCIES
   selenium-webdriver
   spring
   spring-watcher-listen (~> 2.0.0)
-  sqlite3
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/config/database.yml
+++ b/config/database.yml
@@ -21,8 +21,8 @@ development:
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: db_test
 
 production:
   <<: *default
-  database: db/production.sqlite3
+  database: db_production

--- a/db/migrate/20200717033029_create_licenses.rb
+++ b/db/migrate/20200717033029_create_licenses.rb
@@ -1,7 +1,7 @@
 class CreateLicenses < ActiveRecord::Migration[5.2]
   def change
     create_table :licenses do |t|
-      t.references :employee, index: {unique: true}, foreign_key: true
+      t.references :employee, foreign_key: true
       t.string :license, null: false
     end
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -31,7 +31,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_163115) do
     t.string "kana_last_name", null: false
     t.string "kana_first_name", null: false
     t.date "birth_date", null: false
-    t.date "join_date", null: false
+    t.string "join_date", limit: 8, null: false
     t.string "experience", null: false
     t.string "line", null: false
     t.string "station", null: false
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_163115) do
   create_table "licenses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "employee_id"
     t.string "license", null: false
+    t.index ["employee_id"], name: "index_licenses_on_employee_id"
   end
 
   create_table "mst_employee_types", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -74,6 +75,7 @@ ActiveRecord::Schema.define(version: 2020_07_27_163115) do
 
   add_foreign_key "employee_siklls", "employees"
   add_foreign_key "employee_siklls", "mst_skills"
+  add_foreign_key "employees", "mst_employee_types"
   add_foreign_key "employees", "mst_genders"
   add_foreign_key "introductions", "employees"
   add_foreign_key "licenses", "employees"


### PR DESCRIPTION
- `gem 'sqlite3'`の削除

- データベースの作成し直し

- licenseモデルのマイグレーションファイルからunique index指定を削除