### PR TITLE
社員スキル更新時処理追加 #59

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -23,19 +23,20 @@ class EmployeesController < ApplicationController
   end
 
   def create
-    binding.pry
     params[:employee][:birth_date] = join_date
     @employee = Employee.new(employees_params)
     if @employee.save 
       redirect_to controller: 'employees', action: 'index'
     else
-      # set_skills
       render action: 'new'
     end
   end
 
   def edit
-    # binding.pry
+    # スキルが登録されていない場合インスタンスを作成
+    if @employee.employee_siklls.empty?
+      @employee.employee_siklls.build
+    end
   end
 
   def update


### PR DESCRIPTION
1. 社員モデル編集アクション時の処理に以下を追加

- 社員モデルに紐づく、スキルが登録されていない場合に、スキルモデルのインスタンスを作成