### PR TITLE
保有資格登録・編集時の判定処理を追加 #61

### DIFF
--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -33,6 +33,11 @@ class EmployeesController < ApplicationController
   end
 
   def edit
+    # 保有が登録されていない場合インスタンスを作成
+    if @employee.licenses.empty?
+      @employee.licenses.build
+    end
+
     # スキルが登録されていない場合インスタンスを作成
     if @employee.employee_siklls.empty?
       @employee.employee_siklls.build

--- a/app/models/employee.rb
+++ b/app/models/employee.rb
@@ -33,6 +33,7 @@ class Employee < ApplicationRecord
   validates :mst_gender_id, presence: true
   
   #自作バリデーション
+  validate :check_empty_licenses
   validate :license_unique?
   validate :check_empty_skills
   validate :skill_unique?
@@ -41,9 +42,15 @@ class Employee < ApplicationRecord
 
   #社員スキル 登録時に空の場合はレコードを削除する
   def check_empty_skills
-    binding.pry
-    self.employee_siklls.each do |skill|  
+    self.employee_siklls.each do |skill|
       skill.mark_for_destruction if skill[:mst_skill_id].blank? && skill[:sikll_period].blank? && skill[:level].blank?
+    end
+  end
+
+  #保有資格 登録・編集時に空の場合はレコードを削除する
+  def check_empty_licenses
+    self.licenses.each do |license|  
+      license.mark_for_destruction if license[:license].blank?
     end
   end
 


### PR DESCRIPTION
- 社員コントローラの `edit`アクションに保有資格の空チェックを追加
- 社員モデルのバリデーション処理に保有資格が空の場合削除する処理を追加