### PR TITLE
スキルマスタモデル改修 #67

### DIFF
--- a/app/controllers/employee_siklls_controller.rb
+++ b/app/controllers/employee_siklls_controller.rb
@@ -44,11 +44,11 @@ class EmployeeSikllsController < ApplicationController
 
   def set_skills
     @mst_skills = MstSkill.all
-    @os = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:skill_type_code) == 1}
-    @f_language = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:skill_type_code) == 2}
-    @ss_language = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:skill_type_code) == 3}
-    @db = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:skill_type_code) == 4}
-    @fw = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:skill_type_code) == 5}
+    @os = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:mst_skill_category_id) == 1}
+    @f_language = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:mst_skill_category_id) == 2}
+    @ss_language = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:mst_skill_category_id) == 3}
+    @db = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:mst_skill_category_id) == 4}
+    @fw = @mst_skills.select{|skill| skill.read_attribute_before_type_cast(:mst_skill_category_id) == 5}
   end
 
   def employee_skill_params

--- a/app/controllers/employees_controller.rb
+++ b/app/controllers/employees_controller.rb
@@ -50,6 +50,7 @@ class EmployeesController < ApplicationController
   end
 
   def edit
+    binding.pry
     # 保有が登録されていない場合インスタンスを作成
     if @employee.licenses.empty?
       @employee.licenses.build

--- a/app/models/mst_skill.rb
+++ b/app/models/mst_skill.rb
@@ -1,5 +1,5 @@
 class MstSkill < ApplicationRecord
+  belongs_to :mst_skill_category
   has_many :employee_siklls
   has_many :employees, through: :employee_siklls
-  enum skill_type_code: {OS: 1, フロント言語: 2, サーバーサイド言語: 3, データベース: 4, フレームワーク: 5}
 end

--- a/app/models/mst_skill_category.rb
+++ b/app/models/mst_skill_category.rb
@@ -1,0 +1,3 @@
+class MstSkillCategory < ApplicationRecord
+  has_many :mst_skills
+end

--- a/app/views/employee_siklls/_employee_sikll_fields.html.erb
+++ b/app/views/employee_siklls/_employee_sikll_fields.html.erb
@@ -4,7 +4,7 @@
 
 <!-- 仕様変更 -->
 <div class="skill-box-header nested-fields field" id="1">
-  <div class="skill-box-header_top"><%= select_tag  '選択',options_for_select(MstSkill.skill_type_codes, :skill_type_code), class: 'form-select' %></div>
+  <div class="skill-box-header_top"><%= select_tag  '選択',options_from_collection_for_select(MstSkillCategory.all, :id, :category), class: 'form-select' %></div>
   <div class="skill-box-header_wh"><%= f.collection_select :mst_skill_id, MstSkill.all, :id, :skill, {:include_blank => true}, class: 'form-select'  %></div>
   <div class="skill-box-header_bk"><%= f.select :sikll_period, EmployeeSikll.sikll_periods_i18n.invert, {:include_blank => true}, class: 'form-select' %></div>
   <div class="skill-box-header_wh"><%= f.select :level, %w(1 2 3 4 5 6 7 8 9 10), {:include_blank => true}, class: 'form-select' %></div>

--- a/db/fixtures/mst_skill.rb
+++ b/db/fixtures/mst_skill.rb
@@ -1,12 +1,14 @@
 MstSkill.seed_once(:id,
-  {id:1, skill_type_code:1,skill: "Windows"},
-  {id:2, skill_type_code:1,skill: "Mac Os"},
-  {id:3, skill_type_code:2,skill: "HTML・CSS"},
-  {id:4, skill_type_code:2,skill: "JavaScript"},
-  {id:5, skill_type_code:3,skill: "Java"},
-  {id:6, skill_type_code:3,skill: "PHP"},
-  {id:7, skill_type_code:4,skill: "Oracle Database"},
-  {id:8, skill_type_code:4,skill: "Postgresql"}
+  {id:1, mst_skill_category_id:1,skill: "Windows"},
+  {id:2, mst_skill_category_id:1,skill: "Mac Os"},
+  {id:3, mst_skill_category_id:2,skill: "HTML・CSS"},
+  {id:4, mst_skill_category_id:2,skill: "JavaScript"},
+  {id:5, mst_skill_category_id:3,skill: "Java"},
+  {id:6, mst_skill_category_id:3,skill: "PHP"},
+  {id:7, mst_skill_category_id:4,skill: "Oracle Database"},
+  {id:8, mst_skill_category_id:4,skill: "Postgresql"},
+  {id:9, mst_skill_category_id:5,skill: "Ruby on Rails"},
+  {id:10, mst_skill_category_id:5,skill: "Spring Boot"}
 )
 
 

--- a/db/fixtures/mst_skill_category.rb
+++ b/db/fixtures/mst_skill_category.rb
@@ -1,0 +1,7 @@
+MstSkillCategory.seed_once(:id,
+  {id:1, category: 'OS'},
+  {id:2, category: 'フロント言語'},
+  {id:3, category: 'サーバーサイド言語'},
+  {id:4, category: 'データベース'},
+  {id:5, category: 'フレームワーク'}
+)

--- a/db/migrate/20200809041430_create_mst_skill_categories.rb
+++ b/db/migrate/20200809041430_create_mst_skill_categories.rb
@@ -1,0 +1,7 @@
+class CreateMstSkillCategories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :mst_skill_categories do |t|
+      t.string :category
+    end
+  end
+end

--- a/db/migrate/20200809042644_remove_skill_type_code_from_mst_skill.rb
+++ b/db/migrate/20200809042644_remove_skill_type_code_from_mst_skill.rb
@@ -1,0 +1,5 @@
+class RemoveSkillTypeCodeFromMstSkill < ActiveRecord::Migration[5.2]
+  def change
+    # remove_column :mst_skills, :skill_type_code, :integer
+  end
+end

--- a/db/migrate/20200809043112_add_mst_skill_category_ref_to_mstskill.rb
+++ b/db/migrate/20200809043112_add_mst_skill_category_ref_to_mstskill.rb
@@ -1,0 +1,5 @@
+class AddMstSkillCategoryRefToMstskill < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :mst_skills, :mst_skill_category, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_31_093607) do
+ActiveRecord::Schema.define(version: 2020_08_09_043112) do
 
   create_table "employee_seqences", id: :integer, default: nil, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
   end
@@ -71,9 +71,14 @@ ActiveRecord::Schema.define(version: 2020_07_31_093607) do
     t.integer "data_status", null: false
   end
 
+  create_table "mst_skill_categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "category"
+  end
+
   create_table "mst_skills", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.integer "skill_type_code", limit: 1
     t.string "skill"
+    t.bigint "mst_skill_category_id", null: false
+    t.index ["mst_skill_category_id"], name: "index_mst_skills_on_mst_skill_category_id"
   end
 
   add_foreign_key "employee_siklls", "employees"
@@ -82,4 +87,5 @@ ActiveRecord::Schema.define(version: 2020_07_31_093607) do
   add_foreign_key "employees", "mst_genders"
   add_foreign_key "introductions", "employees"
   add_foreign_key "licenses", "employees"
+  add_foreign_key "mst_skills", "mst_skill_categories"
 end

--- a/test/fixtures/mst_skill_categories.yml
+++ b/test/fixtures/mst_skill_categories.yml
@@ -1,0 +1,7 @@
+# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  category: MyString
+
+two:
+  category: MyString

--- a/test/models/mst_skill_category_test.rb
+++ b/test/models/mst_skill_category_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class MstSkillCategoryTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
スキルマスタの修正

1. スキルマスタテーブルから、`mst_skill_type`を削除
2. スキルカテゴリーテーブルを作成し、初期データ投入
3. スキルマスタテーブルに、スキルマスタカテゴリーテーブルへの外部キーを追加
4. 両モデルを関連付け
5. カラム削除に伴い、カラムを参照しているコードを修正